### PR TITLE
agregar y eliminar producto del envio

### DIFF
--- a/src/main/java/edu/pe/pucp/team_1/dp1/sigapucp/Controllers/Facturacion/AgregarProductosEnviosController.java
+++ b/src/main/java/edu/pe/pucp/team_1/dp1/sigapucp/Controllers/Facturacion/AgregarProductosEnviosController.java
@@ -80,7 +80,7 @@ public class AgregarProductosEnviosController implements Initializable {
         columna_codigo.setCellValueFactory((TableColumn.CellDataFeatures<OrdenCompraxProducto, String> p) -> new ReadOnlyObjectWrapper(p.getValue().get("tipo_cod")));
         columna_nombre.setCellValueFactory((TableColumn.CellDataFeatures<OrdenCompraxProducto, String> p) -> new ReadOnlyObjectWrapper(TipoProducto.findById(p.getValue().get("tipo_id")).getString("nombre")));
         columna_descripcion.setCellValueFactory((TableColumn.CellDataFeatures<OrdenCompraxProducto, String> p) -> new ReadOnlyObjectWrapper(TipoProducto.findById(p.getValue().get("tipo_id")).getString("descripcion")));
-        columna_cantidad.setCellValueFactory((TableColumn.CellDataFeatures<OrdenCompraxProducto, String> p) -> new ReadOnlyObjectWrapper(p.getValue().get("cantidad")));
+        columna_cantidad.setCellValueFactory((TableColumn.CellDataFeatures<OrdenCompraxProducto, String> p) -> new ReadOnlyObjectWrapper(p.getValue().get("cantidad_descuento_disponible")));
 
         tabla_productos.setItems(productos);
     }


### PR DESCRIPTION
Se modificó de acuerdo al cambio de bd (ahora guarda la cantidad de cada producto en el envio)
Ya muestra la cantidad disponible del producto en el modal y en el spinner.
Al eliminarlo, la cantidad disponible aumenta.