### PR TITLE
V1.0/s3/improvements/ordenes salida

### DIFF
--- a/src/main/java/edu/pe/pucp/team_1/dp1/sigapucp/Models/Despachos/OrdenSalida.java
+++ b/src/main/java/edu/pe/pucp/team_1/dp1/sigapucp/Models/Despachos/OrdenSalida.java
@@ -19,6 +19,10 @@ import org.javalite.activejdbc.annotations.Table;
 @IdName("salida_id")
 @Many2Many(other = SimulacionBD.class, join = "SimulacionesxDespachos", sourceFKName = "salida_id", targetFKName = "simulacion_id")
 public class OrdenSalida extends Model{
+    static{
+        validatePresenceOf("salida_cod", "tipo", "estado");
+    }
+    
     public enum TIPO
     {
         Venta,


### PR DESCRIPTION
Ya se probó con 2 envios y si los agrega con la cantidad de tipos del producto de cada envio.
Se probó con productos sueltos para rotura u otros.
Se cambiaron nombres de variables más genéricas para mantener estandar. 
Se acomodaron los factory de las columnas de las tablas.